### PR TITLE
Add missing permissions to the DISCORD_INVITE string

### DIFF
--- a/src/main/java/me/hypherionmc/sdlinklib/discord/BotController.java
+++ b/src/main/java/me/hypherionmc/sdlinklib/discord/BotController.java
@@ -59,7 +59,7 @@ public class BotController {
     private final IMinecraftHelper minecraftHelper;
     private DiscordEventHandler discordEventHandler;
 
-    private final String DISCORD_INVITE = "https://discord.com/api/oauth2/authorize?client_id={bot_id}&permissions=738543616&scope=bot%20applications.commands";
+    private final String DISCORD_INVITE = "https://discord.com/api/oauth2/authorize?client_id={bot_id}&permissions=2886028304&scope=bot%20applications.commands";
 
     // Thread Manager
     public static final ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());


### PR DESCRIPTION
In particular, the existing invite is missing the "Manage Channels" permission which prevents the bot from updating the channel topic